### PR TITLE
Don't pass -std= in BUILD.gn

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -64,12 +64,6 @@ config("vulkan_internal_config") {
     "VK_ENABLE_BETA_EXTENSIONS",
   ]
 
-  if (!is_win) {
-    cflags_cc = [ "-std=c++17" ]
-  } else {
-    cflags_cc = [ "/std:c++17" ]
-  }
-
   cflags = []
   if (is_clang || !is_win) {
     cflags += [ "-Wno-unused-function" ]


### PR DESCRIPTION
All embedders use C++17 or newer now, and
language version should generally be set by the
embedder anyways.

This also happens to work around a bug in libc++
which currently doesn't work correctly in mixed
language version modes (https://crbug.com/1463881).